### PR TITLE
hilt di name 미세팅된 부분 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Smeme"
         android:usesCleartextTraffic="true"
+        android:name=".Smeme"
         tools:targetApi="31">
         <activity
             android:name=".presentation.view.TestActivity"


### PR DESCRIPTION
## 요약
- di 사용을 위해 androidManifest 에 android:name 을 세팅해준다.
