### PR TITLE
인터셉터 세팅

### DIFF
--- a/app/src/main/java/com/sopt/smeme/bridge/agent/AgentModule.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/agent/AgentModule.kt
@@ -1,9 +1,11 @@
 package com.sopt.smeme.bridge.agent
 
 import android.content.Context
-import com.sopt.smeme.bridge.agent.user.*
+import com.sopt.smeme.bridge.agent.user.MockSignInAgent
+import com.sopt.smeme.bridge.agent.user.SignInAgent
+import com.sopt.smeme.bridge.agent.user.SocialSignInAgent
+import com.sopt.smeme.bridge.controller.AuthConnection
 import com.sopt.smeme.system.storage.LocalStorage
-import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,7 +23,7 @@ object AgentModule {
         @InjectWay(Way.MOCK)
         fun provideMockSignInAgent(
             @ApplicationContext context: Context,
-            @InjectWay localStorage: LocalStorage
+            @InjectWay(Way.MOCK) localStorage: LocalStorage,
         ): SignInAgent = MockSignInAgent(context, localStorage)
 
         @Provides
@@ -29,7 +31,8 @@ object AgentModule {
         @InjectWay(Way.DEV)
         fun provideSocialSignInAgent(
             @ApplicationContext context: Context,
-            @InjectWay(Way.DEV) localStorage: LocalStorage
-        ): SignInAgent = SocialSignInAgent(context, localStorage)
+            @InjectWay(Way.DEV) localStorage: LocalStorage,
+            authConnection: AuthConnection
+        ): SignInAgent = SocialSignInAgent(context, localStorage, authConnection)
     }
 }

--- a/app/src/main/java/com/sopt/smeme/bridge/agent/InjectWay.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/agent/InjectWay.kt
@@ -3,7 +3,7 @@ package com.sopt.smeme.bridge.agent
 import javax.inject.Qualifier
 
 @Qualifier
-annotation class InjectWay(val way: Way = Way.MOCK)
+annotation class InjectWay(val way: Way = Way.DEV)
 
 enum class Way {
     MOCK,

--- a/app/src/main/java/com/sopt/smeme/bridge/agent/user/MockProfileEditAgent.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/agent/user/MockProfileEditAgent.kt
@@ -9,6 +9,13 @@ import javax.inject.Inject
 class MockProfileEditAgent @Inject constructor(
     profileConnection: ProfileConnection
 ) : ProfileAgent {
-    override suspend fun create(nickname: String, introducing: String)
-    = SimpleResponse(200, true, "success")
+    override suspend fun create(
+        nickname: String,
+        introducing: String,
+        token: String?,
+        onCompleted: () -> Unit,
+        onError: (Throwable) -> Unit
+    ) {
+        onCompleted.invoke()
+    }
 }

--- a/app/src/main/java/com/sopt/smeme/bridge/agent/user/MockSignInAgent.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/agent/user/MockSignInAgent.kt
@@ -15,7 +15,11 @@ class MockSignInAgent @Inject constructor(
     private val localStorage: LocalStorage
 ) : SignInAgent {
 
-    override fun call(type: SignInType.Type, onCompleted: () -> Unit, onError: () -> Unit) {
+    override fun call(
+        type: SignInType.Type,
+        onCompleted: (Boolean) -> Unit,
+        onError: (RuntimeException) -> Unit
+    ) {
         when (type) {
             is Own.OWN -> {}
             is Social.NAVER -> {}
@@ -29,7 +33,7 @@ class MockSignInAgent @Inject constructor(
                         idToken = null
                     )
                 )
-                onCompleted.invoke()
+                onCompleted.invoke(true)
             }
         }
     }

--- a/app/src/main/java/com/sopt/smeme/bridge/agent/user/ProfileAgent.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/agent/user/ProfileAgent.kt
@@ -1,8 +1,13 @@
 package com.sopt.smeme.bridge.agent.user
 
 import com.sopt.smeme.bridge.agent.Agent
-import com.sopt.smeme.bridge.controller.response.SimpleResponse
 
-interface ProfileAgent: Agent {
-    suspend fun create(nickname: String, introducing: String) : SimpleResponse
+interface ProfileAgent : Agent {
+    suspend fun create(
+        nickname: String,
+        introducing: String,
+        token: String?,
+        onCompleted: () -> Unit,
+        onError: (Throwable) -> Unit
+    )
 }

--- a/app/src/main/java/com/sopt/smeme/bridge/agent/user/ProfileEditAgent.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/agent/user/ProfileEditAgent.kt
@@ -1,14 +1,38 @@
 package com.sopt.smeme.bridge.agent.user
 
+import com.sopt.smeme.SmemeException
 import com.sopt.smeme.bridge.agent.response.InitializingProfileRequest
 import com.sopt.smeme.bridge.controller.ProfileConnection
 import dagger.hilt.android.scopes.ViewModelScoped
+import retrofit2.HttpException
 import javax.inject.Inject
 
 @ViewModelScoped
 class ProfileEditAgent @Inject constructor(
     private val profileConnection: ProfileConnection
 ) : ProfileAgent {
-    override suspend fun create(nickname: String, introducing: String) =
-        profileConnection.initialize(InitializingProfileRequest(nickname, introducing))
+    override suspend fun create(
+        nickname: String,
+        introducing: String,
+        token: String?,
+        onCompleted: () -> Unit,
+        onError: (Throwable) -> Unit
+    ) {
+        try {
+            val response = profileConnection.initialize(
+                InitializingProfileRequest(nickname, introducing),
+                "Bearer ${token}"
+            )
+
+            if (response.isSuccessful()) {
+                onCompleted.invoke()
+            }
+
+            throw SmemeException(response.status, response.message ?: "관리자에 문의하세요.")
+        } catch (s: SmemeException) {
+            onError.invoke(s)
+        } catch (e: HttpException) {
+            onError.invoke(e)
+        }
+    }
 }

--- a/app/src/main/java/com/sopt/smeme/bridge/agent/user/SignInAgent.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/agent/user/SignInAgent.kt
@@ -4,5 +4,9 @@ import com.sopt.smeme.SignInType
 import com.sopt.smeme.bridge.agent.Agent
 
 interface SignInAgent : Agent {
-    fun call(type: SignInType.Type, onCompleted: () -> Unit, onError: () -> Unit)
+    fun call(
+        type: SignInType.Type,
+        onCompleted: (Boolean) -> Unit,
+        onError: (RuntimeException) -> Unit
+    )
 }

--- a/app/src/main/java/com/sopt/smeme/bridge/agent/user/SocialSignInAgent.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/agent/user/SocialSignInAgent.kt
@@ -1,43 +1,98 @@
 package com.sopt.smeme.bridge.agent.user
 
 import android.content.Context
+import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
 import com.sopt.smeme.Own
 import com.sopt.smeme.SignInType
+import com.sopt.smeme.SmemeException
 import com.sopt.smeme.Social
+import com.sopt.smeme.bridge.controller.AuthConnection
+import com.sopt.smeme.bridge.controller.request.AuthenticateRequest
 import com.sopt.smeme.system.storage.AccessData
 import com.sopt.smeme.system.storage.LocalStorage
+import com.sopt.smeme.system.storage.UserData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import timber.log.Timber
 import javax.inject.Inject
 
-
 class SocialSignInAgent @Inject constructor(
-    val context: Context,
-    private val localStorage: LocalStorage
+    private val context: Context,
+    private val localStorage: LocalStorage,
+    private val authConnection: AuthConnection
 ) : SignInAgent {
+    var oAuthToken: OAuthToken? = null
 
-    override fun call(type: SignInType.Type, onCompleted: () -> Unit, onError: () -> Unit) {
-        when (type) {
-            is Own.OWN -> {}
-            is Social.NAVER -> {}
-            is Social.KAKAO -> {
-                UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+    override fun call(
+        type: SignInType.Type,
+        onCompleted: (Boolean) -> Unit,
+        onError: (RuntimeException) -> Unit
+    ) = when (type) {
+        is Own.OWN -> {}
+        is Social.NAVER -> {}
+        is Social.KAKAO -> {
 
-                    // TODO : control error detail
-                    if (error != null) {
-                        Timber.e(error, "로그인 실패")
-                        onError.invoke()
-                    } else if (token != null) {
-                        localStorage.save(
-                            AccessData(
-                                accessToken = token.accessToken,
-                                refreshToken = token.refreshToken,
-                                accessExpired = token.accessTokenExpiresAt,
-                                refreshExpired = token.refreshTokenExpiresAt,
-                                idToken = token.idToken
-                            )
+            UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+                // kakao 로 부터 error 가 내려온 경우
+                if (error != null) {
+                    Timber.e(error, "로그인 실패")
+                    onError.invoke(SmemeException(500, "social server 인증에서 오류가 발생했습니다."))
+                }
+
+                // token 이 정상적으로 전달된 경우
+                else if (token != null) {
+                    val oAuthToken = token
+
+                    // local storage 에 kakao 정보를 담는다.
+                    localStorage.save(
+                        AccessData(
+                            accessToken = oAuthToken.accessToken,
+                            refreshToken = oAuthToken.refreshToken,
+                            accessExpired = oAuthToken.accessTokenExpiresAt,
+                            refreshExpired = oAuthToken.refreshTokenExpiresAt,
+                            idToken = oAuthToken.idToken
                         )
-                        onCompleted.invoke()
+                    )
+
+                    // server 로 토큰 요청을 한다.
+                    CoroutineScope(Dispatchers.IO).launch {
+                        try {
+                            val response = authConnection.login(
+                                AuthenticateRequest(social = "kakao"),
+                                "Bearer ${oAuthToken.accessToken}"
+                            )
+
+                            // server 로 부터 200 응답이 옴
+                            if (response.isSuccessful()) {
+                                // save access info in local storage
+                                val data = response.data
+                                if (data == null) {
+                                    throw SmemeException(500, "api server 로 부터 토큰 값이 넘어오지 않았습니다.")
+                                } else {
+                                    // 이미 등록된 회원
+                                    if (data.isRegistered) {
+                                        localStorage.authorize()
+                                    } else {
+
+                                    }
+                                    localStorage.save(
+                                        UserData(
+                                            accessToken = data.accessToken,
+                                            refreshToken = data.refreshToken,
+                                            id = null
+                                        )
+                                    )
+                                    onCompleted.invoke(data.isRegistered)
+                                }
+                            } else {
+                                onError.invoke(SmemeException(response.status, response.message))
+                            }
+                        } catch (e: HttpException) {
+                            onError.invoke(e)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/sopt/smeme/bridge/controller/ApiConnectionModule.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/controller/ApiConnectionModule.kt
@@ -2,6 +2,7 @@ package com.sopt.smeme.bridge.controller
 
 import com.sopt.smeme.system.network.Cluster
 import com.sopt.smeme.system.network.ConnectCluster
+import com.sopt.smeme.system.network.ConnectionType
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -26,6 +27,16 @@ object ApiConnectionModule {
     object User {
         @Provides
         @ViewModelScoped
+        fun provideLogin(
+            @ConnectCluster(
+                Cluster.ORIGIN,
+                ConnectionType.AUTHORIZE
+            ) retrofit: Retrofit
+        ): AuthConnection =
+            retrofit.create(AuthConnection::class.java)
+
+        @Provides
+        @ViewModelScoped
         fun provideProfileInitializer(@ConnectCluster(Cluster.ORIGIN) retrofit: Retrofit): ProfileConnection =
             retrofit.create(ProfileConnection::class.java)
 
@@ -36,7 +47,7 @@ object ApiConnectionModule {
     object MDir {
         @Provides
         @ViewModelScoped
-        fun provideMyDiaryConnection(@ConnectCluster(Cluster.ORIGIN) retrofit: Retrofit) : MyDiaryConnection =
+        fun provideMyDiaryConnection(@ConnectCluster(Cluster.ORIGIN) retrofit: Retrofit): MyDiaryConnection =
             retrofit.create(MyDiaryConnection::class.java)
     }
 

--- a/app/src/main/java/com/sopt/smeme/bridge/controller/AuthConnection.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/controller/AuthConnection.kt
@@ -1,0 +1,16 @@
+package com.sopt.smeme.bridge.controller
+
+import com.sopt.smeme.bridge.controller.request.AuthenticateRequest
+import com.sopt.smeme.bridge.controller.response.DataResponse
+import com.sopt.smeme.bridge.controller.response.ServiceAccessData
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+
+interface AuthConnection {
+    @POST("/api/v1/auth")
+    suspend fun login(
+        @Body request: AuthenticateRequest,
+        @Header("Authorization") socialToken: String
+    ): DataResponse<ServiceAccessData>
+}

--- a/app/src/main/java/com/sopt/smeme/bridge/controller/ProfileConnection.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/controller/ProfileConnection.kt
@@ -3,6 +3,7 @@ package com.sopt.smeme.bridge.controller
 import com.sopt.smeme.bridge.agent.response.InitializingProfileRequest
 import com.sopt.smeme.bridge.controller.response.SimpleResponse
 import retrofit2.http.Body
+import retrofit2.http.Header
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 
@@ -11,6 +12,7 @@ interface ProfileConnection : Connection {
     // TODO : accessToken interceptor
     @PATCH("/api/v1/users")
     suspend fun initialize(
-        @Body request: InitializingProfileRequest
+        @Body request: InitializingProfileRequest,
+        @Header(value = "Authorization") token: String? = ""
     ): SimpleResponse
 }

--- a/app/src/main/java/com/sopt/smeme/bridge/controller/request/AuthenticateRequest.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/controller/request/AuthenticateRequest.kt
@@ -1,0 +1,10 @@
+package com.sopt.smeme.bridge.controller.request
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AuthenticateRequest(
+    @SerializedName("social")
+    val social: String
+)

--- a/app/src/main/java/com/sopt/smeme/bridge/controller/request/Profile.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/controller/request/Profile.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class InitializingProfileRequest(
-    val name: String, // Mandatory, not blank
+    val username: String, // Mandatory, not blank
     val bio: String, // Mandatory
 )

--- a/app/src/main/java/com/sopt/smeme/bridge/controller/response/ServiceAccessData.kt
+++ b/app/src/main/java/com/sopt/smeme/bridge/controller/response/ServiceAccessData.kt
@@ -1,0 +1,10 @@
+package com.sopt.smeme.bridge.controller.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ServiceAccessData(
+    val accessToken: String,
+    val refreshToken: String,
+    val isRegistered: Boolean
+)

--- a/app/src/main/java/com/sopt/smeme/business/policy/ProfilePolicy.kt
+++ b/app/src/main/java/com/sopt/smeme/business/policy/ProfilePolicy.kt
@@ -2,5 +2,5 @@ package com.sopt.smeme.business.policy
 
 object ProfilePolicy {
     // fun
-    fun acceptNickname(text: String) = text.length > 5
+    fun acceptNickname(text: String) = text.length > 0
 }

--- a/app/src/main/java/com/sopt/smeme/business/viewmodel/Receptionist.kt
+++ b/app/src/main/java/com/sopt/smeme/business/viewmodel/Receptionist.kt
@@ -5,21 +5,31 @@ import com.sopt.smeme.SignInType
 import com.sopt.smeme.bridge.agent.InjectWay
 import com.sopt.smeme.bridge.agent.Way
 import com.sopt.smeme.bridge.agent.user.SignInAgent
+import com.sopt.smeme.bridge.controller.AuthConnection
+import com.sopt.smeme.system.storage.LocalStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class Receptionist @Inject constructor(
-    @InjectWay(Way.MOCK) val signInAgent: SignInAgent
+    @InjectWay(Way.DEV) private val signInAgent: SignInAgent,
+    @InjectWay(Way.DEV) private val localStorage: LocalStorage,
+    val authConnection: AuthConnection
 ) : ViewModel(), ViewModelFrame {
 
     // onCompleted : 로그인 성공 후 행위
     // onError : 에러시 행위
     fun handle(
         type: SignInType.Type,
-        onCompleted: () -> Unit, // Mandatory
-        onError: () -> Unit = {}  // Optional
+        onCompleted: (Boolean) -> Unit, // Mandatory
+        onError: (Throwable) -> Unit = {}  // Optional
     ) {
-        signInAgent.call(type, onCompleted, onError)
+        try {
+            signInAgent.call(type, onCompleted, onError)
+        } catch (t: Throwable) {
+            onError(t)
+            Timber.e(t)
+        }
     }
 }

--- a/app/src/main/java/com/sopt/smeme/business/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/com/sopt/smeme/business/viewmodel/SplashViewModel.kt
@@ -4,13 +4,15 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.sopt.smeme.Event
-import com.sopt.smeme.system.storage.LocalSharedPreference
+import com.sopt.smeme.bridge.agent.InjectWay
+import com.sopt.smeme.bridge.agent.Way
+import com.sopt.smeme.system.storage.LocalStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val localStorage: LocalSharedPreference
+    @InjectWay(Way.DEV) private val localStorage: LocalStorage
 ) : ViewModel(), ViewModelFrame {
     private val _isSignedUser = MutableLiveData<Event<Boolean>>()
     val isSignedUser: LiveData<Event<Boolean>> get() = _isSignedUser

--- a/app/src/main/java/com/sopt/smeme/presentation/view/welcome/LoginProfileActivity.kt
+++ b/app/src/main/java/com/sopt/smeme/presentation/view/welcome/LoginProfileActivity.kt
@@ -9,8 +9,7 @@ import com.sopt.smeme.R
 import com.sopt.smeme.business.policy.ProfilePolicy
 import com.sopt.smeme.business.viewmodel.ProfileInitializer
 import com.sopt.smeme.databinding.ActivityLoginProfileBinding
-import com.sopt.smeme.presentation.view.BinderActivity
-import com.sopt.smeme.presentation.view.TestActivity
+import com.sopt.smeme.presentation.view.HomeActivity
 import com.sopt.smeme.presentation.view.ViewBoundActivity
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -18,10 +17,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class LoginProfileActivity :
     ViewBoundActivity<ActivityLoginProfileBinding>(R.layout.activity_login_profile) {
     private val profileInitializer: ProfileInitializer by viewModels()
-
-    override fun constructLayout() {
-
-    }
 
     override fun listen() {
         // text 의 작성 상태를 observe //
@@ -43,35 +38,18 @@ class LoginProfileActivity :
             if (ProfilePolicy.acceptNickname(nickname)) {
                 profileInitializer.initialize(nickname, introducing,
                     onCompleted = {
-                        val toMain = Intent(this, TestActivity::class.java)
+                        val toMain = Intent(this, HomeActivity::class.java)
                         startActivity(toMain)
                         finish()
                     },
                     onError = {
-                        if (it == null) {
-                            Toast.makeText(this, "정상적인 접근이 아닙니다.", Toast.LENGTH_SHORT).show()
-                        }
-                        if (it?.code() == 401) {
-                            Toast.makeText(this, "정상적인 접근이 아닙니다 (${it.code()})", Toast.LENGTH_SHORT)
+                        runOnUiThread {
+                            Toast.makeText(this, it.message, Toast.LENGTH_SHORT)
                                 .show()
-                        } else {
-                            Toast.makeText(
-                                this,
-                                "내부적인 오류입니다. 관리자에 문의하세요. (${it?.code()})",
-                                Toast.LENGTH_SHORT
-                            ).show()
                         }
-
-                        val toBinding = Intent(this, BinderActivity::class.java)
-                        startActivity(toBinding)
-                        finish()
                     })
             }
         }
-    }
-
-    override fun observe() {
-        super.observe()
     }
 
     private fun clearNickname() = binding.etLoginProfileNickname.text.clear()
@@ -93,9 +71,6 @@ class LoginProfileActivity :
         }
 
         override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-        override fun afterTextChanged(s: Editable?) {
-
-        }
-
+        override fun afterTextChanged(s: Editable?) {}
     }
 }

--- a/app/src/main/java/com/sopt/smeme/presentation/view/welcome/OnBoardingActivity.kt
+++ b/app/src/main/java/com/sopt/smeme/presentation/view/welcome/OnBoardingActivity.kt
@@ -1,19 +1,28 @@
 package com.sopt.smeme.presentation.view.welcome
 
 import android.content.Intent
+import android.widget.Toast
 import androidx.activity.viewModels
 import com.sopt.smeme.R
 import com.sopt.smeme.Social
+import com.sopt.smeme.bridge.agent.InjectWay
+import com.sopt.smeme.bridge.agent.Way
 import com.sopt.smeme.business.viewmodel.Receptionist
 import com.sopt.smeme.databinding.ActivityOnBoardingBinding
-import com.sopt.smeme.presentation.view.TestActivity
+import com.sopt.smeme.presentation.view.HomeActivity
 import com.sopt.smeme.presentation.view.ViewBoundActivity
+import com.sopt.smeme.system.storage.LocalStorage
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class OnBoardingActivity :
     ViewBoundActivity<ActivityOnBoardingBinding>(R.layout.activity_on_boarding) {
     private val receptionist: Receptionist by viewModels()
+
+    @Inject
+    @InjectWay(Way.DEV)
+    lateinit var localStorage: LocalStorage
 
     override fun listen() {
         binding.btnOnBoardingKakao.setOnClickListener {
@@ -21,10 +30,24 @@ class OnBoardingActivity :
             // -> KAKAO 외 소셜 혹은 자체 로그인 확장에 대비
             receptionist.handle(
                 type = Social.KAKAO,
-                onCompleted = { startActivity(Intent(this, TestActivity::class.java)) }
+                onCompleted = {
+                    // isRegistered true
+                    if (it) {
+                        startActivity(Intent(this, HomeActivity::class.java))
+                    }
+                    // isRegistered false -> Profile
+                    else {
+                        startActivity(Intent(this, LoginProfileActivity::class.java))
+                    }
+                    finish()
+                },
+                onError = {
+                    runOnUiThread {
+                        Toast.makeText(this, it.message, Toast.LENGTH_SHORT)
+                            .show()
+                    }
+                }
             )
-            
-            finish()
         }
     }
 

--- a/app/src/main/java/com/sopt/smeme/presentation/view/welcome/SplashActivity.kt
+++ b/app/src/main/java/com/sopt/smeme/presentation/view/welcome/SplashActivity.kt
@@ -7,7 +7,7 @@ import com.sopt.smeme.EventObserver
 import com.sopt.smeme.R
 import com.sopt.smeme.business.viewmodel.SplashViewModel
 import com.sopt.smeme.databinding.ActivitySplashBinding
-import com.sopt.smeme.presentation.view.BinderActivity
+import com.sopt.smeme.presentation.view.HomeActivity
 import com.sopt.smeme.presentation.view.ViewBoundActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -31,9 +31,9 @@ class SplashActivity : ViewBoundActivity<ActivitySplashBinding>(R.layout.activit
         startActivity(
             Intent(
                 this@SplashActivity, if (isSigned) {
-                    BinderActivity::class.java
+                    HomeActivity::class.java
                 } else {
-                    BinderActivity::class.java
+                    OnBoardingActivity::class.java
                 }
             )
         )

--- a/app/src/main/java/com/sopt/smeme/system/network/ConnectCluster.kt
+++ b/app/src/main/java/com/sopt/smeme/system/network/ConnectCluster.kt
@@ -5,7 +5,10 @@ import com.sopt.smeme.system.network.AddressUtil.domain
 import javax.inject.Qualifier
 
 @Qualifier
-annotation class ConnectCluster(val cluster: Cluster = Cluster.ORIGIN)
+annotation class ConnectCluster(
+    val cluster: Cluster = Cluster.ORIGIN,
+    val connectionType: ConnectionType = ConnectionType.ACCESS
+)
 
 enum class Cluster(
     val default: String,
@@ -19,4 +22,14 @@ enum class Cluster(
 
     fun node() = default
     fun node(target: String) = nodes.getOrDefault(target, default)
+}
+
+@Qualifier
+annotation class ConnectionWay(
+    val connectionType: ConnectionType = ConnectionType.ACCESS
+)
+
+enum class ConnectionType {
+    ACCESS,
+    AUTHORIZE
 }

--- a/app/src/main/java/com/sopt/smeme/system/network/NetworkModule.kt
+++ b/app/src/main/java/com/sopt/smeme/system/network/NetworkModule.kt
@@ -1,6 +1,9 @@
 package com.sopt.smeme.system.network
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.sopt.smeme.HomeAccess
+import com.sopt.smeme.system.storage.LocalSharedPreference
+import com.sopt.smeme.system.storage.UserData
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,24 +19,69 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 class NetworkModule {
-
     @ExperimentalSerializationApi
     @Provides
     @Singleton
-    @ConnectCluster(Cluster.ORIGIN)
-    fun provideNodeApiBaseRetrofit(client: OkHttpClient, json: Json): Retrofit = Retrofit.Builder()
+    @ConnectCluster(Cluster.ORIGIN, ConnectionType.AUTHORIZE)
+    fun provideAuthConnectionRetrofit(
+        @ConnectionWay(ConnectionType.AUTHORIZE) client: OkHttpClient, json: Json
+    ): Retrofit = Retrofit.Builder()
         .baseUrl(Cluster.ORIGIN.node())
         .client(client)
         .addConverterFactory(json.asConverterFactory(requireNotNull("application/json".toMediaTypeOrNull())))
         .build()
 
+    /**
+     * 인증 시에는 token setting 을 하지 않는다.
+     */
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient =
+    @ConnectionWay(ConnectionType.AUTHORIZE)
+    fun provideAuthOkHttpClient(): OkHttpClient =
+        OkHttpClient.Builder().apply {
+            connectTimeout(10, TimeUnit.SECONDS)
+            writeTimeout(10, TimeUnit.SECONDS)
+            readTimeout(10, TimeUnit.SECONDS)
+        }.build()
+
+    @ExperimentalSerializationApi
+    @Provides
+    @Singleton
+    @ConnectCluster(Cluster.ORIGIN)
+    fun provideNodeApiBaseRetrofit(
+        @ConnectionWay(ConnectionType.ACCESS) client: OkHttpClient,
+        json: Json
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(Cluster.ORIGIN.node())
+        .client(client)
+        .addConverterFactory(json.asConverterFactory(requireNotNull("application/json".toMediaTypeOrNull())))
+        .build()
+
+    /**
+     * api 요청 시에는 token setting 이 필요하다.
+     */
+    @Provides
+    @Singleton
+    @ConnectionWay(ConnectionType.ACCESS)
+    fun provideAccessOkHttpClient(
+        localStorage: LocalSharedPreference
+    ): OkHttpClient =
         OkHttpClient.Builder().apply {
             connectTimeout(5, TimeUnit.SECONDS)
             writeTimeout(5, TimeUnit.SECONDS)
             readTimeout(5, TimeUnit.SECONDS)
+
+            val userToken = localStorage.get(HomeAccess)
+            if (localStorage.isAuthenticated()) {
+                if (userToken is UserData) {
+                    addInterceptor(
+                        RequestInterceptor(
+                            userToken.accessToken ?: "",
+                            userToken.refreshToken
+                        )
+                    )
+                }
+            }
         }.build()
 
     @OptIn(ExperimentalSerializationApi::class)

--- a/app/src/main/java/com/sopt/smeme/system/network/RequestInterceptor.kt
+++ b/app/src/main/java/com/sopt/smeme/system/network/RequestInterceptor.kt
@@ -1,0 +1,21 @@
+package com.sopt.smeme.system.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class RequestInterceptor(
+    val accessToken: String,
+    val refreshToken: String?
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return chain.proceed(
+            chain.request().newBuilder()
+                .header("Authorization", "$BEARER$accessToken")
+                .build()
+        )
+    }
+
+    companion object {
+        private const val BEARER = "Bearer "
+    }
+}

--- a/app/src/main/java/com/sopt/smeme/system/storage/LocalDataStoreStorage.kt
+++ b/app/src/main/java/com/sopt/smeme/system/storage/LocalDataStoreStorage.kt
@@ -12,4 +12,13 @@ class LocalDataStoreStorage : LocalStorage {
 
     // TODO
     override fun isAuthenticated() = false
+
+    // TODO
+    override fun isSocialAuthenticated() = false
+
+    // TODO
+    override fun authorize() = Unit
+
+    // TODO
+    override fun getAccessToken() = ""
 }

--- a/app/src/main/java/com/sopt/smeme/system/storage/LocalStorage.kt
+++ b/app/src/main/java/com/sopt/smeme/system/storage/LocalStorage.kt
@@ -6,6 +6,9 @@ interface LocalStorage {
     fun save(data: Data)
     fun get(accessType: UserAccessType): Data
     fun isAuthenticated(): Boolean
+    fun isSocialAuthenticated() : Boolean
+    fun authorize(): Unit
+    fun getAccessToken() : String?
 
     sealed interface Data {
         fun hasValue(): Boolean
@@ -27,5 +30,6 @@ interface LocalStorage {
         const val KAKAO_ID_TOKEN = "kakaoIdToken"
         const val KAKAO_ACCESS_EXPIRED = "kakaoAccessExpired"
         const val KAKAO_REFRESH_EXPIRED = "kakaoRefreshExpired"
+        const val SOCIAL_CHECKED = "socialChecked"
     }
 }


### PR DESCRIPTION
## 요약
- 인증이된 경우 (accessToken 및 유저 닉네임도 세팅된 경우)
  - 요청 api 마다 header 에 token 값이 담기도록 구성

### AS-IS
- 요청 시 token 을 정적으로 담아주었다.
- 유저 닉네임이 세팅이 되지 않은 경우 (isRegistered : false) 에도 home 으로 접근이 가능했다. 

### TO-BE
- local storage 에서 자동 로그인 기준을 isRegistered 로 한다.
  - 카카오 로그인 성공 후 기존에 접속했던 회원 (닉네임 있음) 인 경우 (isRegistered : true)
  - 카카오 로그인 성공 후 첫 접속인 회원 (닉네임 없음) 인 경우, 닉네임 세팅까지 완료되면 자동로그인 set
 
## 반영일정

